### PR TITLE
Use https by default for endpoint

### DIFF
--- a/oss2/api.py
+++ b/oss2/api.py
@@ -2506,10 +2506,16 @@ class Bucket(_Base):
 
 
 def _normalize_endpoint(endpoint):
+    """规范化endpoint，默认启用 https 以增加安全性。该接口返回规范化后的 URL 字符串。
+
+    :param endpoint: 合法的 URL 字符串，参考 RFC 1738。
+
+    :return: 规范化后的 URL 字符串。
+    """
     url = endpoint
 
     if not endpoint.startswith('http://') and not endpoint.startswith('https://'):
-        url = 'http://' + endpoint
+        url = 'https://' + endpoint
 
     p = urlparse(url)
 


### PR DESCRIPTION
Using https by default is one of the security best practice rules nowadays.
Azure also have been using https by default, you can refer to [_blob_client.py](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py)

With this changes, the existing programs of consumers might fail with `CERTIFICATE_VERIFY_FAILED` if they didn't specify `http://` explicitly and certificates on their server not yet configured correctly.

To avoid surprise from consumers of this lib, please broadcast to developers and customers in Aliyun community and relevant guides before merge/release with this changes.